### PR TITLE
GOV.UK Frontend 4.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Gem](https://img.shields.io/gem/dt/govuk_design_system_formbuilder?logo=rubygems)](https://rubygems.org/gems/govuk_design_system_formbuilder)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/110136fb22341d3ba646/test_coverage)](https://codeclimate.com/github/x-govuk/govuk-form-builder/test_coverage)
 [![GitHub license](https://img.shields.io/github/license/x-govuk/govuk-form-builder)](https://github.com/x-govuk/govuk-form-builder/blob/main/LICENSE)
-[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.6.0-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.7.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.0.4-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-3.0.5%20%20%E2%95%B1%203.1.3%20%20%E2%95%B1%203.2.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -29,7 +29,7 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | GOV.UK Design System
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 4.6.0
+        | 4.7.0
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.14.0
     tr.govuk-table__row

--- a/guide/content/stylesheets/application.scss
+++ b/guide/content/stylesheets/application.scss
@@ -58,37 +58,3 @@ $govuk-brand-colour: #28a;
 .branded-background {
   background: govuk-colour(blue);
 }
-
-// inverse buttons, this can be removed once the functionality is supported by
-// the design system. https://github.com/alphagov/govuk-frontend/pull/3556
-$govuk-inverse-button-colour: govuk-colour("white");
-$govuk-inverse-button-text-colour: govuk-colour("blue");
-$govuk-inverse-button-hover-colour: govuk-tint($govuk-inverse-button-text-colour, 90%);
-$govuk-inverse-button-shadow-colour: govuk-shade($govuk-inverse-button-text-colour, 30%);
-
-.govuk-button--inverse {
-  background-color: $govuk-inverse-button-colour;
-  box-shadow: 0 2px 0 $govuk-inverse-button-shadow-colour;
-
-  &,
-  &:link,
-  &:visited,
-  &:active,
-  &:hover {
-    color: $govuk-inverse-button-text-colour;
-  }
-
-  @include _govuk-compatibility(govuk_template) {
-    &:link:focus {
-      color: $govuk-inverse-button-text-colour;
-    }
-  }
-
-  &:hover {
-    background-color: $govuk-inverse-button-hover-colour;
-
-    &[disabled] {
-      background-color: $govuk-inverse-button-colour;
-    }
-  }
-}

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^4.6.0",
+        "govuk-frontend": "^4.7.0",
         "sass": "^1.57.1"
       }
     },
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
-      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -284,9 +284,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
-      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
     },
     "immutable": {
       "version": "4.2.2",

--- a/guide/package.json
+++ b/guide/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^4.6.0",
+    "govuk-frontend": "^4.7.0",
     "sass": "^1.57.1"
   }
 }


### PR DESCRIPTION
- Upgrade to GOV.UK frontend 4.7.0
- Remove CSS for inverse buttons
