### PR TITLE
Allow merging data-aria-controls

### DIFF
--- a/lib/govuk_design_system_formbuilder/traits/fieldset_item.rb
+++ b/lib/govuk_design_system_formbuilder/traits/fieldset_item.rb
@@ -25,7 +25,7 @@ module GOVUKDesignSystemFormBuilder
           class: classes,
           multiple: @multiple,
           aria: { describedby: [hint_id.presence] },
-          data: { 'aria-controls' => @conditional_id }
+          data: { aria_controls: @conditional_id },
         }
       end
 


### PR DESCRIPTION
We have a situation where we want to add additional DOM ids to the `aria-controls` attribute of a govuk form element.

The `x-govuk/html-attributes-utils` is used to merge attributes. It handles merging `aria-controls` but not `data-aria-controls`. It's unclear to me why `data-aria-controls` is used here. It seems like the front end javascript moves the data-aria-controls into aria-controls. Can we just set `aria-controls` directly?

If setting `data-aria-controls` rather than `aria-controls` is important, perhaps we could instead modify `x-govuk/html-attributes-utils` to also merge `%i[data aria controls]`