### PR TITLE
Add warning message for supplemental content

### DIFF
--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -1,9 +1,12 @@
 require 'pry'
+require 'rails'
 require 'action_view'
 require 'active_model'
 require 'active_support/core_ext/string'
 require 'htmlbeautifier'
 require 'slim/erb_converter'
+
+Rails.logger = Logger.new($stdout)
 
 Dir.glob(File.join('./lib', '**', '*.rb')).sort.each { |f| require f }
 

--- a/lib/govuk_design_system_formbuilder/containers/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/containers/supplemental.rb
@@ -10,6 +10,8 @@ module GOVUKDesignSystemFormBuilder
       def html
         return if @content.blank?
 
+        warn("Supplemental content is deprecated and support will soon be removed. See https://github.com/x-govuk/govuk-form-builder/issues/445")
+
         tag.div(id: supplemental_id) { @content }
       end
 

--- a/spec/support/shared/shared_block_examples.rb
+++ b/spec/support/shared/shared_block_examples.rb
@@ -25,6 +25,15 @@ shared_examples 'a field that accepts arbitrary blocks of HTML' do
         with_tag('p', text: block_p)
       end
     end
+
+    describe "deprecation warning message" do
+      before { allow(Rails).to receive_message_chain(:logger, :warn).with(any_args).and_return(true) }
+
+      specify 'logs a deprecation warning' do
+        subject
+        expect(Rails.logger).to have_received(:warn).with(/Supplemental content is deprecated/)
+      end
+    end
   end
 
   context 'when no block is supplied' do


### PR DESCRIPTION
The supplemental conent the form builder allows to be passed in via a block, which is rendered between the hint text and input, isn't very accessible. It encourages the use of longer text than would ordinarily be used in a hint, but screen readers will read out the entire message, which doesn't make for a great user experience.

Refs #445
