### PR TITLE
Fix GOV.UK frontend JavaScript setup in the guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ guide/*.log
 guide/node_modules
 guide/content/assets/images
 guide/content/javascripts/*.js
+guide/content/javascripts/*.map
 
 crash.log

--- a/guide/layouts/partials/footer.slim
+++ b/guide/layouts/partials/footer.slim
@@ -25,6 +25,7 @@ footer.govuk-footer role="contentinfo"
       .govuk-footer__meta-item
           | © X-GOVUK
 
-script src="/javascripts/govuk-frontend.js"
-script
-  | window.GOVUKFrontend.initAll() ;
+script type="module" src="/javascripts/govuk-frontend.min.js"
+script type="module"
+  | import { initAll } from '/javascripts/govuk-frontend.min.js';
+  | initAll();

--- a/guide/layouts/partials/header.slim
+++ b/guide/layouts/partials/header.slim
@@ -1,5 +1,5 @@
 script
-  | document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+  | document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
 
 a.govuk-skip-link href="#main-content"
   | Skip to main content

--- a/guide/package.json
+++ b/guide/package.json
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "postinstall": "cp -R node_modules/govuk-frontend/dist/govuk/assets/images content/assets && cp node_modules/govuk-frontend/dist/govuk/all.bundle.js content/javascripts/govuk-frontend.js",
+    "postinstall": "cp -R node_modules/govuk-frontend/dist/govuk/assets/images content/assets && cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js content/javascripts/govuk-frontend.min.js && cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js.map content/javascripts/govuk-frontend.min.js.map",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
- Switch to using .min.js throughout and copy map
- Switch to new syntax for enabling govuk-frontend
