### PR TITLE
Fix spacing on code examples in the guide

### DIFF
--- a/guide/content/stylesheets/components/_prose.scss
+++ b/guide/content/stylesheets/components/_prose.scss
@@ -43,6 +43,9 @@ $app-code-fg: govuk-shade(govuk-colour("pink"), 10%);
     color: $app-code-fg;
     font-family: ui-monospace, monospace;
     font-size: 1rem;
+  }
+
+  p > code {
     padding: 2px govuk-spacing(1);
   }
 


### PR DESCRIPTION
The `code` selector is adding some padding to the code blocks as well as the inline code, which makes the first line slightly more indented than those that follow. It's only really noticable in some examples (like the error) where there are a few lines.

This change targets the code tags directly in paragraphs, leaving blocks unaffected.


| Before | Closeup | After |
| -------- | ------- | -------- |
| ![Screenshot from 2024-01-03 12-04-28](https://github.com/x-govuk/govuk-form-builder/assets/128088/ebf190d9-90b2-496b-90e4-a7af896a094a)|![image](https://github.com/x-govuk/govuk-form-builder/assets/128088/4f73642c-a162-4b7d-ac06-eeafbe8bd14c) | ![Screenshot from 2024-01-03 12-04-28](https://github.com/x-govuk/govuk-form-builder/assets/128088/94e70a8a-a6cb-47ff-97a3-47a3e9a2a180) |

