### PR TITLE
Date part specific errors

### DIFF
--- a/guide/content/form-elements/date-input.slim
+++ b/guide/content/form-elements/date-input.slim
@@ -56,6 +56,11 @@ ul.govuk-list.govuk-list--bullet
       | Date inputs without a day field are not currently part of the GOV.UK Design System
 
 == render('/partials/example.*',
+  caption: 'Experimental date segment stuff',
+  code: date_field_with_segment_specific_error,
+  show_errors: :date_segments)
+
+== render('/partials/example.*',
   caption: 'Specifying client side length restrictions on date inputs with maxlength',
   code: maxlength_enabled_field) do
 

--- a/guide/lib/examples/date.rb
+++ b/guide/lib/examples/date.rb
@@ -26,5 +26,12 @@ module Examples
           hint: { text: 'Use the format day, month, year, for example 27 3 2021' }
       SNIPPET
     end
+
+    def date_field_with_segment_specific_error
+      <<~SNIPPET
+        = f.govuk_date_field :retirement_date,
+          legend: { text: 'When do you expect to retire?' }
+      SNIPPET
+    end
   end
 end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -67,7 +67,8 @@ class Person
   # date fields
   attr_accessor(
     :date_of_birth,
-    :graduation_month
+    :graduation_month,
+    :retirement_date
   )
 
   # labels, captions, hints and legends
@@ -100,11 +101,16 @@ class Person
   validates :welcome_lunch_choice, presence: { message: 'Select a lunch choice for your first day' }, on: :fields
 
   validate :telephone_number_or_email_address_exists, on: :base_errors
+  validate :retirement_date_year_must_be_in_the_future, on: :date_segments
 
   def telephone_number_or_email_address_exists
     if telephone_number.blank? && email_address.blank?
       errors.add(:base, "Enter a telephone number or email address")
     end
+  end
+
+  def retirement_date_year_must_be_in_the_future
+    errors.add(:retirement_date_year, "Year must be later than #{Date.today.year}")
   end
 
   # fieldset
@@ -124,4 +130,10 @@ class Person
     :favourite_kind_of_hat,
     :role
   )
+
+  def initialize(...)
+    self.retirement_date = Date.new(Date.today.year - 1, 5, 5)
+
+    super
+  end
 end

--- a/guide/lib/setup/form_builder_objects.rb
+++ b/guide/lib/setup/form_builder_objects.rb
@@ -8,6 +8,8 @@ module Setup
         builder_with_base_errors
       when :presenters
         builder_with_presenter_errors
+      when :date_segments
+        builder_with_date_segment_errors
       else
         builder_without_errors
       end
@@ -29,6 +31,10 @@ module Setup
       GOVUKDesignSystemFormBuilder::FormBuilder.new(:person, object_with_presenter_errors, helper, {})
     end
 
+    def builder_with_date_segment_errors
+      GOVUKDesignSystemFormBuilder::FormBuilder.new(:person, object_with_date_segment_errors, helper, {})
+    end
+
     def object
       Person.new
     end
@@ -43,6 +49,10 @@ module Setup
 
     def object_with_presenter_errors
       Person.new.tap { |p| p.valid?(:presenters) }
+    end
+
+    def object_with_date_segment_errors
+      Person.new.tap { |p| p.valid?(:date_segments) }
     end
 
     def helper

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -25,9 +25,9 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        Containers::FormGroup.new(*bound, **@form_group, **@html_attributes).html do
+        Containers::FormGroup.new(*bound, **@form_group, **@html_attributes, on_date_field: true).html do
           Containers::Fieldset.new(*bound, **fieldset_options).html do
-            safe_join([supplemental_content, hint_element, error_element, date])
+            safe_join([supplemental_content, hint_element, error_element(on_date_field: true), date])
           end
         end
       end
@@ -110,7 +110,7 @@ module GOVUKDesignSystemFormBuilder
       def input(segment, link_errors, width, value)
         tag.input(
           id: id(segment, link_errors),
-          class: classes(width),
+          class: classes(segment, width),
           name: name(segment),
           type: 'text',
           inputmode: 'numeric',
@@ -120,13 +120,17 @@ module GOVUKDesignSystemFormBuilder
         )
       end
 
-      def classes(width)
+      def classes(segment, width)
         build_classes(
           %(input),
           %(date-input__input),
           %(input--width-#{width}),
-          %(input--error) => has_errors?,
+          %(input--error) => segment_has_errors?(segment)
         ).prefix(brand)
+      end
+
+      def segment_has_errors?(segment)
+        attribute_has_errors? || attribute_has_date_segment_error_on?(segment)
       end
 
       # if the field has errors we want the govuk_error_summary to

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -20,7 +20,17 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def message
-        set_message_safety(@builder.object.errors.messages[@attribute_name]&.first)
+        set_message_safety(all_messages&.first)
+      end
+
+      def all_messages
+        @builder.object.errors.messages[@attribute_name].dup.tap do |messages|
+          if @on_date_field
+            date_segment_names.each do |segment|
+              messages.concat(@builder.object.errors.messages[%(#{@attribute_name}_#{segment}).to_sym])
+            end
+          end
+        end
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/error.rb
+++ b/lib/govuk_design_system_formbuilder/traits/error.rb
@@ -9,8 +9,8 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
-      def error_element
-        @error_element ||= Elements::ErrorMessage.new(*bound)
+      def error_element(on_date_field: false)
+        @error_element ||= Elements::ErrorMessage.new(*bound, on_date_field:)
       end
 
       def set_message_safety(message)

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -307,5 +307,90 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    describe "errors specific to a date part" do
+      let(:day_attributes) { { name: "person[born_on(3i)]", class: "govuk-input" } }
+      let(:month_attributes) { { name: "person[born_on(2i)]", class: "govuk-input" } }
+      let(:year_attributes) { { name: "person[born_on(1i)]", class: "govuk-input" } }
+
+      describe "when there is a problem with the day" do
+        let(:error_message) { "must be between 1 and 31" }
+        before { object.errors.add(:born_on_day, error_message) }
+
+        specify "the form group has an error class" do
+          expect(subject).to have_tag("div", with: { class: %w(govuk-form-group govuk-form-group--error) })
+        end
+
+        specify "the error message is displayed" do
+          expect(subject).to have_tag("p", with: { class: "govuk-error-message" }, text: "Error: #{error_message}")
+        end
+
+        specify "the day field has error classes" do
+          expect(subject).to have_tag("input", with: { name: "person[born_on(3i)]", class: "govuk-input--error" })
+        end
+
+        specify "the month and year fields don't have error classes" do
+          expect(subject).to have_tag("input", with: month_attributes)
+          expect(subject).to have_tag("input", with: year_attributes)
+          expect(subject).not_to have_tag("input", with: { **month_attributes, class: "govuk-input--error" })
+          expect(subject).not_to have_tag("input", with: { **year_attributes, class: "govuk-input--error" })
+        end
+
+        specify "the ID of the input with the error matches the href in the error summary"
+      end
+
+      describe "when there is a problem with the month" do
+        let(:error_message) { "must be between 1 and 12" }
+        before { object.errors.add(:born_on_month, error_message) }
+
+        specify "the form group has an error class" do
+          expect(subject).to have_tag("div", with: { class: %w(govuk-form-group govuk-form-group--error) })
+        end
+
+        specify "the error message is displayed" do
+          expect(subject).to have_tag("p", with: { class: "govuk-error-message" }, text: "Error: #{error_message}")
+        end
+
+        specify "the month field has error classes" do
+          expect(subject).to have_tag("input", with: { name: "person[born_on(2i)]", class: "govuk-input--error" })
+        end
+
+        specify "the day and year fields don't have error classes" do
+          expect(subject).to have_tag("input", with: day_attributes)
+          expect(subject).to have_tag("input", with: year_attributes)
+          expect(subject).not_to have_tag("input", with: { **day_attributes, class: "govuk-input--error" })
+          expect(subject).not_to have_tag("input", with: { **year_attributes, class: "govuk-input--error" })
+        end
+
+        specify "the ID of the input with the error matches the href in the error summary"
+      end
+
+      describe "when there is a problem with the year" do
+        let(:error_message) { "must be greater than 1900" }
+        before { object.errors.add(:born_on_year, error_message) }
+
+        specify "the form group has an error class" do
+          expect(subject).to have_tag("div", with: { class: %w(govuk-form-group govuk-form-group--error) })
+        end
+
+        specify "the year field has error classes" do
+          expect(subject).to have_tag("input", with: { name: "person[born_on(1i)]", class: "govuk-input--error" })
+        end
+
+        specify "the day and month fields don't have error classes" do
+          expect(subject).to have_tag("input", with: day_attributes)
+          expect(subject).to have_tag("input", with: month_attributes)
+          expect(subject).not_to have_tag("input", with: { **day_attributes, class: "govuk-input--error" })
+          expect(subject).not_to have_tag("input", with: { **month_attributes, class: "govuk-input--error" })
+        end
+
+        specify "the ID of the input with the error matches the href in the error summary"
+      end
+
+      describe "when there are multiple date segment errors" do
+        specify "only the first one is shown"
+        specify "the ID of the input with the error matches the href in the error summary"
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -1,7 +1,7 @@
 describe GOVUKDesignSystemFormBuilder::FormBuilder do
   include_context 'setup builder'
 
-  describe '#date_input_group' do
+  describe '#date_field' do
     let(:method) { :govuk_date_field }
     let(:attribute) { :born_on }
 


### PR DESCRIPTION
The GOV.UK Design System now recommends that when part of a date is incorrect it should be individually highlighted.

This is problematic because:

* A date is a single thing, it is either valid or invalid
* When multiple things could be wrong which do we highlight? (currently it will just show the first one in date/month/year order)
* Ruby's [Date class](https://ruby-doc.org/3.3.0/exts/date/Date.html), which is used by Rails, doesn't have any concept of somewhat-valid dates

The problems above mean we need to treat dates as a special case and developers will need to intercept Rails' validation and do their own.

This change adds support for showing custom error messages and highlighting the appropriate fields in the form builder. It does it by checking date fields for extra errors on the field that end with `_day`, `_month` or `_year` (i.e. `retirement_date_year`). If they are present:

* [x] the date field's form group will be marked as containing errors
* [x] the error message will be shown
* [x] the input at fault will get the `govuk-input-error` class and a red 
* [ ] the error summary will link to the input with the error

![Screenshot from 2024-01-14 15-53-48](https://github.com/x-govuk/govuk-form-builder/assets/128088/47f503f4-45b6-4e99-8cd6-70eede64c32a)

## Problems

* adding _magic_ attributes that we check for error messages isn't very robust, if a developer adds both `payment_date` and `payment_date_year` to their object and exposes both in the form the error summary will likely link to both
* there's a lot of work and additional testing required by teams to implement this custom logic and special validation
* the validation needs to be applied in a particular way. The example in the [Design System documentation](https://design-system.service.gov.uk/components/date-input/#error-messages) shows a date without a year. Rails will try to parse the input into a `Date` very early on - before the model gets hold of it to apply validation. Handling this safely and cleanly is non-trivial and beyond the scope of this library

## Changes

- Rename the outer spec describe block
- Add specs covering date segment specific errors
- Add date segment specific behaviour
- Add [date segment section to the guide](https://deploy-preview-462--govuk-form-builder.netlify.app/form-elements/date-input/#experimental-date-segment-stuff)