### PR TITLE
Upgrade supported Ruby versions to 3.1, 3.2, 3.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0.6', '3.1.4', '3.2.2']
+        ruby: ['3.1.4', '3.2.3', '3.3.0']
         rails: ['6.1.7', '7.0.6']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub license](https://img.shields.io/github/license/x-govuk/govuk-form-builder)](https://github.com/x-govuk/govuk-form-builder/blob/main/LICENSE)
 [![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-5.0.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.0.6-E16D6D)](https://weblog.rubyonrails.org/releases/)
-[![Ruby](https://img.shields.io/badge/Ruby-3.0.6%20%20%E2%95%B1%203.1.4%20%20%E2%95%B1%203.2.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Ruby](https://img.shields.io/badge/Ruby-3.1.4%20%20%E2%95%B1%203.2.3%20%20%E2%95%B1%203.3.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 
 This library provides an easy-to-use form builder for the [GOV.UK Design System](https://design-system.service.gov.uk/).
 

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -47,11 +47,11 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | Ruby
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 3.2.2
+        | 3.3.0
+        br
+        | 3.2.3
         br
         | 3.1.4
-        br
-        | 3.0.6
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.0.3
         br


### PR DESCRIPTION
This drops support for Ruby 3.0 as it's no longer in the last 3 major releases.
