### PR TITLE
Make it clearer how to set hint text on checkboxes

### DIFF
--- a/guide/lib/examples/checkboxes.rb
+++ b/guide/lib/examples/checkboxes.rb
@@ -6,7 +6,10 @@ module Examples
           departments,
           :id,
           :name,
-          legend: { text: "Which department do you work in?" }
+          caption: nil,
+          legend: { text: "Which departments do you work in?" },
+          hint: { text: "Select all departments that apply" }
+
       SNIPPET
     end
 
@@ -17,7 +20,8 @@ module Examples
           :id,
           :name,
           :description,
-          legend: { text: "What is your preferred lunch option?" }
+          hint: { text: "Select all options you are happy to eat" },
+          legend: { text: "What are your preferred lunch options?" }
       SNIPPET
     end
 


### PR DESCRIPTION
This makes it a bit clearer how to set the hint text within the legend for checkboxes. Currently it's being set by some text in a localisation file, but this isn’t shown in the example.

Also reworded the examples slightly to make them plural, so that it’s more obvious that uses can select more than one answer. 