### PR TITLE
Add warnings on `belongs_to` presence validation field mismatch

### DIFF
--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -50,4 +50,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("slim", "~> 5.2.0")
   s.add_development_dependency("slim_lint", "~> 0.26.0")
   s.add_development_dependency("webrick", "~> 1.8.1")
+  s.add_development_dependency("redcarpet", "~> 3.6.0")
 end

--- a/guide/content/form-elements/checkboxes.slim
+++ b/guide/content/form-elements/checkboxes.slim
@@ -17,6 +17,8 @@ p.govuk-body
     hidden field can be toggled using the <code>multiple</code> keyword
     argument.
 
+== render('/partials/belongs-to-warning.*')
+
 == render('/partials/example.*',
   caption: 'Generating a collection of checkboxes',
   code: checkbox_field,

--- a/guide/content/form-elements/radios.slim
+++ b/guide/content/form-elements/radios.slim
@@ -16,6 +16,8 @@ p.govuk-body
     practice as it means that users of screen readers will only hear the
     contents once.
 
+== render('/partials/belongs-to-warning.*')
+
 == render('/partials/example.*',
   caption: 'Radios collection with legend and hint text',
   code: radio_field_with_legend_and_hint,

--- a/guide/content/form-elements/select.slim
+++ b/guide/content/form-elements/select.slim
@@ -15,6 +15,8 @@ p.govuk-body
     | Asking questions means you're less likely to need to use the select
       component and can consider using a different solution, such as radios.
 
+== render('/partials/belongs-to-warning.*')
+
 == render('/partials/example.*',
   caption: 'Select field with a label and hint',
   code: select_field_with_label_and_hint,

--- a/guide/layouts/partials/belongs-to-warning.slim
+++ b/guide/layouts/partials/belongs-to-warning.slim
@@ -1,0 +1,20 @@
+.govuk-notification-banner[
+  role="region"
+  aria-labelledby="govuk-notification-banner-title"
+  data-module="govuk-notification-banner"
+]
+  .govuk-notification-banner__header
+    .govuk-notification-banner__title
+      | Important
+  .govuk-notification-banner__content
+    markdown:
+      Note that Rails now adds presence validation to associations
+      automatically but usually we set relationships by assigning values to the
+      foreign key column.
+
+      This results in errors being added to the object on attributes that don't
+      appear in the form, for example on `department` instead of
+      `department_id`.
+
+      You can suppress this behaviour by adding `optional: true` to the relationship
+      and manually adding the presence validation to the foreign key field yourself.


### PR DESCRIPTION
Add warning on Rails relationship presence checks

This problem has occurred since Rails added default validation to Rails' belongs_to relationships in version 6.

Usually when creating forms we set relationships using the foreign key column, i.e. `department_id`, not the `department` relationship
attribute itself .

This mismatch causes errors on the object to be reported in the error summary but they won't link properly to the input because it's mapped to a different field.

Solving the problem itself is complex so this is a tentative first step and adds warnings to the guide.

It's _really hard_ to concisely say what's going on, any feedback on wording welcome.

Refs #411

## Changes

- Add RedCarpet markdown rendering to the guide
- Add warning on Rails relationship presence checks

## Preview

(possible misuse of notification banner component 🚨)

![image](https://github.com/x-govuk/govuk-form-builder/assets/128088/58135bdf-9b62-4484-baa8-74e3621240ab)

