### PR TITLE
Remove guide hover colour override

### DIFF
--- a/guide/content/stylesheets/application.scss
+++ b/guide/content/stylesheets/application.scss
@@ -4,8 +4,8 @@ $govuk-assets-path: "/assets/";
 $govuk-font-family: system-ui, sans-serif;
 $govuk-brand-colour: #2288aa;
 $govuk-link-colour: #006688;
-$govuk-hover-colour: #004466;
-$govuk-visited-colour: #333366;
+$govuk-link-hover-colour: #004466;
+$govuk-link-visited-colour: #333366;
 $govuk-page-width: 1100px;
 
 // Import GOV.UK Frontend


### PR DESCRIPTION
The only place I can see it have an impact is on small radios and the dark blue looks a bit odd.

Here is the Design System on the left and the guide on the right before the change:

![Screenshot from 2024-02-03 19-47-58](https://github.com/x-govuk/govuk-form-builder/assets/128088/f9ce6bd3-d8aa-4ea7-8d85-a25ccbf34b53)

After the change they'll look the same. Not sure what else this affects though! 🙈 