### PR TITLE
Make the default date segments configurable

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -27,6 +27,11 @@ module GOVUKDesignSystemFormBuilder
   # * +:default_submit_button_text+ sets the value assigned to +govuk_submit+,
   #   defaults to 'Continue'.
   #
+  # * +:default_date_segments+ allows the date segments used by Rails'
+  #   multiparameter attributes to be configured. This is useful if you want to
+  #   override the standard behaviour where Rails tries to cast the values
+  #   into a +Date+. Defaults to +{ day: '3i', month: '2i', year: '1i' }+
+  #
   # * +:default_radio_divider_text+ sets the text automatically added to the
   #   radio button divider, defaults to 'or'
   #
@@ -88,6 +93,7 @@ module GOVUKDesignSystemFormBuilder
     default_legend_tag: nil,
     default_caption_size: 'm',
     default_submit_button_text: 'Continue',
+    default_date_segments: { day: '3i', month: '2i', year: '1i' },
     default_radio_divider_text: 'or',
     default_check_box_divider_text: 'or',
     default_error_summary_title: 'There is a problem',

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -8,7 +8,6 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Supplemental
       include Traits::HTMLClasses
 
-      SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
       MULTIPARAMETER_KEY = { day: 3, month: 2, year: 1 }.freeze
 
       def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, maxlength_enabled:, form_group:, date_of_birth: false, **kwargs, &block)
@@ -33,6 +32,10 @@ module GOVUKDesignSystemFormBuilder
       end
 
     private
+
+      def segments
+        config.default_date_segments
+      end
 
       def fieldset_options
         { legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id] }
@@ -136,7 +139,7 @@ module GOVUKDesignSystemFormBuilder
         if has_errors? && link_errors
           field_id(link_errors:)
         else
-          [@object_name, @attribute_name, SEGMENTS.fetch(segment)].join("_")
+          [@object_name, @attribute_name, segments.fetch(segment)].join("_")
         end
       end
 
@@ -145,7 +148,7 @@ module GOVUKDesignSystemFormBuilder
           "%<object_name>s[%<input_name>s(%<segment>s)]",
           object_name: @object_name,
           input_name: @attribute_name,
-          segment: SEGMENTS.fetch(segment)
+          segment: segments.fetch(segment)
         )
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/configuration/date_segment_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/date_segment_configuration_spec.rb
@@ -1,0 +1,25 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+  include_context 'setup examples'
+
+  after { GOVUKDesignSystemFormBuilder.reset! }
+
+  describe 'default date segments' do
+    let(:overridden_segments) { { day: 'c', month: 'b', year: 'a' } }
+
+    before do
+      GOVUKDesignSystemFormBuilder.configure do |conf|
+        conf.default_date_segments = overridden_segments
+      end
+    end
+
+    subject { builder.govuk_date_field(:govuk_date_field) }
+
+    specify 'uses the configured date segments' do
+      overridden_segments.each do |segment, value|
+        expect(subject).to have_tag("label", with: { for: "person_govuk_date_field_#{value}" }, text: segment.capitalize)
+        expect(subject).to have_tag("input", with: { name: "person[govuk_date_field(#{value})]" })
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change should make it easier for people to add custom date validation by giving them control of the identifiers used by Rails' multiparameter fields.

This was suggested in #489 and in [the linked PR] the `i` (which tells Rails to cast to an Integer) is removed, allowing the custom validation to take place before Rails tries casting the values to a `Date`.
