### PR TITLE
Make date segments overridable

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -922,6 +922,8 @@ module GOVUKDesignSystemFormBuilder
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @param omit_day [Boolean] do not render a day input, only capture month and year
     # @param maxlength_enabled [Boolean] adds maxlength attribute to day, month and year inputs (2, 2, and 4, respectively)
+    # @param segments [Hash] allows Rails' multiparameter attributes to be overridden on a field-by-field basis. Hash must
+    #   contain +day:+, +month:+ and +year:+ keys. Defaults to the default value set in the +default_date_segments+ setting in {GOVUKDesignSystemFormBuilder.DEFAULTS}
     # @param form_group [Hash] configures the form group
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
@@ -944,8 +946,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, maxlength_enabled: false, form_group: {}, **kwargs, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint:, legend:, caption:, date_of_birth:, omit_day:, maxlength_enabled:, form_group:, **kwargs, &block).html
+    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, maxlength_enabled: false, segments: config.default_date_segments, form_group: {}, **kwargs, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint:, legend:, caption:, date_of_birth:, omit_day:, maxlength_enabled:, segments:, form_group:, **kwargs, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -10,7 +10,7 @@ module GOVUKDesignSystemFormBuilder
 
       MULTIPARAMETER_KEY = { day: 3, month: 2, year: 1 }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, maxlength_enabled:, form_group:, date_of_birth: false, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, maxlength_enabled:, segments:, form_group:, date_of_birth: false, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
         @legend            = legend
@@ -19,6 +19,7 @@ module GOVUKDesignSystemFormBuilder
         @date_of_birth     = date_of_birth
         @omit_day          = omit_day
         @maxlength_enabled = maxlength_enabled
+        @segments          = segments
         @form_group        = form_group
         @html_attributes   = kwargs
       end
@@ -32,10 +33,6 @@ module GOVUKDesignSystemFormBuilder
       end
 
     private
-
-      def segments
-        config.default_date_segments
-      end
 
       def fieldset_options
         { legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id] }
@@ -139,7 +136,7 @@ module GOVUKDesignSystemFormBuilder
         if has_errors? && link_errors
           field_id(link_errors:)
         else
-          [@object_name, @attribute_name, segments.fetch(segment)].join("_")
+          [@object_name, @attribute_name, @segments.fetch(segment)].join("_")
         end
       end
 
@@ -148,7 +145,7 @@ module GOVUKDesignSystemFormBuilder
           "%<object_name>s[%<input_name>s(%<segment>s)]",
           object_name: @object_name,
           input_name: @attribute_name,
-          segment: segments.fetch(segment)
+          segment: @segments.fetch(segment)
         )
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -136,6 +136,22 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    context 'when segments are overridden' do
+      subject { builder.send(*args, segments: { day: "day", month: "month", year: "year" }) }
+
+      specify "sets the day field correctly" do
+        expect(subject).to have_tag('input', with: { id: "person_born_on_day", name: "person[born_on(day)]" })
+      end
+
+      specify "sets the month field correctly" do
+        expect(subject).to have_tag('input', with: { id: "person_born_on_month", name: "person[born_on(month)]" })
+      end
+
+      specify "sets the year field correctly" do
+        expect(subject).to have_tag('input', with: { id: "person_born_on_year", name: "person[born_on(year)]" })
+      end
+    end
+
     context 'showing only month and year inputs' do
       subject { builder.send(*args, omit_day: true) }
 


### PR DESCRIPTION
Following on from #493 this allows the date segments to be overridden on a field-by-field basis instead of just at the app level.
