### PR TITLE
Add hidden attribute to the password show button

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/password.rb
+++ b/lib/govuk_design_system_formbuilder/elements/password.rb
@@ -85,6 +85,7 @@ module GOVUKDesignSystemFormBuilder
           data: { module: %(#{brand}-button) },
           aria: { label: "Show password", controls: field_id(link_errors: true) },
           type: 'button',
+          hidden: true,
           class: %w(button button--secondary password-input__toggle js-password-input-toggle).prefix(brand)
         }
       end

--- a/spec/govuk_design_system_formbuilder/builder/password_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/password_spec.rb
@@ -48,6 +48,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     specify 'the button has the right attributes' do
       expected_attributes = {
+        "hidden" => "hidden",
         "data-module" => "govuk-button",
         "aria-label" => "Show password",
         "aria-controls" => "person-password-field",


### PR DESCRIPTION
This was missed when the password field was initially added. It means the show/hide button can be rendered hidden and then shown if/when the JavaScript kicks in. When missing the button is rendered and it doesn't do anything.

Huge thanks to @colinrotherham for helping diagnose 🙌

Fixes #495
