### PR TITLE
Allow legend size to be nil

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -65,6 +65,8 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def size_class(size)
+        return nil if size.nil?
+
         fail "invalid size '#{size}', must be xl, l, m or s" unless size.in?(%w(xl l m s))
 
         %(fieldset__legend--#{size})

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -41,6 +41,7 @@ shared_examples 'a field that supports a fieldset with legend' do
       context 'valid sizes' do
         %w(s m l xl).each do |size|
           let(:size) { size }
+
           context %(when the legend size is #{size}) do
             subject { builder.send(*args, legend: { text: legend_text, size: }) }
 
@@ -51,6 +52,17 @@ shared_examples 'a field that supports a fieldset with legend' do
                 end
               end
             end
+          end
+        end
+
+        context 'when the legend size is nil' do
+          subject { builder.send(*args, legend: { text: legend_text, size: nil }) }
+
+          specify 'the size class should be absent' do
+            expect(subject).to_not have_tag('legend', with: { class: 'govuk-fieldset__legend--s' })
+            expect(subject).to_not have_tag('legend', with: { class: 'govuk-fieldset__legend--m' })
+            expect(subject).to_not have_tag('legend', with: { class: 'govuk-fieldset__legend--l' })
+            expect(subject).to_not have_tag('legend', with: { class: 'govuk-fieldset__legend--xl' })
           end
         end
       end


### PR DESCRIPTION
This updates the legend element to allow the size attribute to be `nil`, and when `nil` a size class won't be specified for the element. This is required to support the case where a field has a legend element but shouldn't have a size class.

There's an example of this kind of component in the GOV.UK Design System:

https://design-system.service.gov.uk/components/date-input/#if-youre-asking-more-than-one-question-on-the-page

It's currently not possible to re-create this example using purely the form builder classes as the size is enforced as one of `s`, `m`, `l` or `xl`.