### PR TITLE
Allow brand overrides on a per-helper basis

### DIFF
--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -3,10 +3,13 @@ module GOVUKDesignSystemFormBuilder
     delegate :content_tag, :safe_join, :tag, :link_to, :capture, to: :@builder
     delegate :config, to: GOVUKDesignSystemFormBuilder
 
-    def initialize(builder, object_name, attribute_name, &block)
+    # FIXME remove the `= nil` from override_brand once the rest of the super calls
+    #       have been updated
+    def initialize(builder, object_name, attribute_name, override_brand = nil, &block)
       @builder        = builder
       @object_name    = object_name
       @attribute_name = attribute_name
+      @override_brand = override_brand
       @block_content  = capture { block.call } if block_given?
     end
 
@@ -47,8 +50,12 @@ module GOVUKDesignSystemFormBuilder
       [@builder, @object_name, @attribute_name]
     end
 
-    def brand(override = nil)
+    def brand(override = @override_brand)
       override || config.brand
+    end
+
+    def brand_options
+      { brand: @override_brand }
     end
 
     def has_errors?

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -925,6 +925,7 @@ module GOVUKDesignSystemFormBuilder
     # @param maxlength_enabled [Boolean] adds maxlength attribute to day, month and year inputs (2, 2, and 4, respectively)
     # @param segments [Hash] allows Rails' multiparameter attributes to be overridden on a field-by-field basis. Hash must
     #   contain +day:+, +month:+ and +year:+ keys. Defaults to the default value set in the +default_date_segments+ setting in {GOVUKDesignSystemFormBuilder.DEFAULTS}
+    # @param brand [String] override the default brand prefix for this input
     # @param form_group [Hash] configures the form group
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
@@ -947,8 +948,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, maxlength_enabled: false, segments: config.default_date_segments, form_group: {}, **kwargs, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint:, legend:, caption:, date_of_birth:, omit_day:, maxlength_enabled:, segments:, form_group:, **kwargs, &block).html
+    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, maxlength_enabled: false, segments: config.default_date_segments, form_group: {}, brand: nil, **kwargs, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint:, legend:, caption:, date_of_birth:, omit_day:, maxlength_enabled:, segments:, form_group:, brand:, **kwargs, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -881,6 +881,7 @@ module GOVUKDesignSystemFormBuilder
     # @param block [Block] When content is passed in via a block the submit element and the block content will
     #   be wrapped in a +<div class="govuk-button-group">+ which will space the buttons and links within
     #   evenly.
+    # @param brand [String] override the default brand prefix for this input
     # @raise [ArgumentError] raised if both +warning+ and +secondary+ are true
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @note Only the first additional button or link (passed in via a block) will be given the
@@ -895,8 +896,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, inverse: false, prevent_double_click: true, validate: config.default_submit_validate, disabled: false, **kwargs, &block)
-      Elements::Submit.new(self, text, warning:, secondary:, inverse:, prevent_double_click:, validate:, disabled:, **kwargs, &block).html
+    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, inverse: false, prevent_double_click: true, validate: config.default_submit_validate, disabled: false, brand: nil, **kwargs, &block)
+      Elements::Submit.new(self, text, warning:, secondary:, inverse:, prevent_double_click:, validate:, disabled:, brand:, **kwargs, &block).html
     end
 
     # Generates three inputs for the +day+, +month+ and +year+ components of a date

--- a/lib/govuk_design_system_formbuilder/containers/button_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/button_group.rb
@@ -1,8 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class ButtonGroup < Base
-      def initialize(builder, buttons)
-        super(builder, nil, nil)
+      def initialize(builder, buttons, brand:)
+        super(builder, nil, nil, brand)
 
         @buttons = buttons
       end

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -3,8 +3,8 @@ module GOVUKDesignSystemFormBuilder
     class Fieldset < Base
       include Traits::HTMLAttributes
 
-      def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, caption: {}, described_by: nil, **kwargs, &block)
-        super(builder, object_name, attribute_name, &block)
+      def initialize(builder, object_name = nil, attribute_name = nil, brand:, legend: {}, caption: {}, described_by: nil, **kwargs, &block)
+        super(builder, object_name, attribute_name, brand, &block)
 
         @legend          = legend
         @caption         = caption
@@ -36,7 +36,7 @@ module GOVUKDesignSystemFormBuilder
         @legend_element ||= if @legend.nil?
                               Elements::Null.new
                             else
-                              Elements::Legend.new(*bound, **legend_options)
+                              Elements::Legend.new(*bound, **brand_options, **legend_options)
                             end
       end
 

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -4,8 +4,8 @@ module GOVUKDesignSystemFormBuilder
       include Traits::HTMLAttributes
       include Traits::HTMLClasses
 
-      def initialize(builder, object_name, attribute_name, **kwargs)
-        super(builder, object_name, attribute_name)
+      def initialize(builder, object_name, attribute_name, brand:, **kwargs)
+        super(builder, object_name, attribute_name, brand)
 
         @html_attributes = kwargs
       end

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -10,8 +10,8 @@ module GOVUKDesignSystemFormBuilder
 
       MULTIPARAMETER_KEY = { day: 3, month: 2, year: 1 }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, maxlength_enabled:, segments:, form_group:, date_of_birth: false, **kwargs, &block)
-        super(builder, object_name, attribute_name, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, maxlength_enabled:, segments:, form_group:, brand:, date_of_birth: false, **kwargs, &block)
+        super(builder, object_name, attribute_name, brand, &block)
 
         @legend            = legend
         @caption           = caption
@@ -25,8 +25,8 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        Containers::FormGroup.new(*bound, **@form_group, **@html_attributes).html do
-          Containers::Fieldset.new(*bound, **fieldset_options).html do
+        Containers::FormGroup.new(*bound, **brand_options, **@form_group, **@html_attributes).html do
+          Containers::Fieldset.new(*bound, **brand_options, **fieldset_options).html do
             safe_join([supplemental_content, hint_element, error_element, date])
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -8,8 +8,8 @@ module GOVUKDesignSystemFormBuilder
       include Traits::HTMLAttributes
       include Traits::HTMLClasses
 
-      def initialize(builder, object_name, attribute_name, text: nil, size: config.default_legend_size, hidden: false, tag: config.default_legend_tag, caption: nil, content: nil, **kwargs)
-        super(builder, object_name, attribute_name)
+      def initialize(builder, object_name, attribute_name, brand:, text: nil, size: config.default_legend_size, hidden: false, tag: config.default_legend_tag, caption: nil, content: nil, **kwargs)
+        super(builder, object_name, attribute_name, brand)
 
         if content
           @content = capture { content.call }

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -5,8 +5,8 @@ module GOVUKDesignSystemFormBuilder
       include Traits::HTMLClasses
       include Traits::HTMLAttributes
 
-      def initialize(builder, text, warning:, secondary:, inverse:, prevent_double_click:, validate:, disabled:, **kwargs, &block)
-        super(builder, nil, nil)
+      def initialize(builder, text, warning:, secondary:, inverse:, prevent_double_click:, validate:, disabled:, brand:, **kwargs, &block)
+        super(builder, nil, nil, brand)
 
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
 
@@ -39,7 +39,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def button_group
-        Containers::ButtonGroup.new(@builder, buttons).html
+        Containers::ButtonGroup.new(@builder, buttons, brand: @brand).html
       end
 
       def buttons

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -67,6 +67,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the hint via localisation'
 
     it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that allows branding to be explicitly overriden'
     it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that supports a fieldset with legend'

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -10,6 +10,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     include_examples 'HTML formatting checks'
 
     it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that allows branding to be explicitly overriden'
 
     it_behaves_like 'a field that supports custom classes' do
       let(:element) { 'button' }

--- a/spec/support/shared/shared_supports_branding_examples.rb
+++ b/spec/support/shared/shared_supports_branding_examples.rb
@@ -18,3 +18,18 @@ shared_examples 'a field that supports custom branding' do
     expect(subject).not_to match(Regexp.new(default_brand))
   end
 end
+
+shared_examples 'a field that allows branding to be explicitly overriden' do
+  let(:custom_brand) { 'globex-corp' }
+  let(:default_brand) { 'govuk' }
+
+  subject { builder.send(*args, brand: custom_brand) }
+
+  specify 'should contain the custom branding' do
+    expect(subject).to match(Regexp.new(custom_brand))
+  end
+
+  specify 'should not contain any default branding' do
+    expect(subject).not_to match(Regexp.new(default_brand))
+  end
+end


### PR DESCRIPTION
Allow brand to be overridden on a per field basis.

This feature was originally requested against [govuk-components](https://github.com/x-govuk/govuk-components/issues/547) but I'm testing the approach here first - it should be easy to reuse there.
