### PR TITLE
Upgrade to latest versions of Ruby and Rails

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install gems
         env:
-          RAILS_VERSION: '7.0.8'
+          RAILS_VERSION: '7.1.5'
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.1.6', '3.2.4', '3.3.4']
-        rails: ['6.1.7', '7.0.8', '7.1.3']
+        ruby: ['3.2.5', '3.3.6']
+        rails: ['7.1.5', '7.2.2', '8.0.0']
     runs-on: ubuntu-latest
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     steps:

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/110136fb22341d3ba646/test_coverage)](https://codeclimate.com/github/x-govuk/govuk-form-builder/test_coverage)
 [![GitHub license](https://img.shields.io/github/license/x-govuk/govuk-form-builder)](https://github.com/x-govuk/govuk-form-builder/blob/main/LICENSE)
 [![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-5.7.0-brightgreen)](https://design-system.service.gov.uk)
-[![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.1.3-E16D6D)](https://weblog.rubyonrails.org/releases/)
-[![Ruby](https://img.shields.io/badge/Ruby-3.1.6%20%20%E2%95%B1%203.2.4%20%20%E2%95%B1%203.3.4-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Rails](https://img.shields.io/badge/Rails-7.1.5%20%E2%95%B1%207.2.2%20%E2%95%B1%208.0.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
+[![Ruby](https://img.shields.io/badge/Ruby-3.2.6%20%20%E2%95%B1%203.3.6-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 
 This library provides an easy-to-use form builder for the [GOV.UK Design System](https://design-system.service.gov.uk/).
 

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -36,11 +36,11 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | Ruby on Rails
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 7.1.3
+        | 8.0.0
         br
-        | 7.0.8
+        | 7.2.2
         br
-        | 6.1.7
+        | 7.1.5
       td.govuk-table__cell.govuk-table__cell--numeric
         | 6.1.4.4
         br
@@ -49,11 +49,9 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | Ruby
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 3.3.4
+        | 3.3.6
         br
-        | 3.2.4
-        br
-        | 3.1.6
+        | 3.2.5
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.0.3
         br


### PR DESCRIPTION
Ruby 3.1 support is dropped because Rails 8 depends on Ruby 3.2 and above.