### PR TITLE
Add flag for JS enhanced file upload

### DIFF
--- a/guide/content/form-elements/file-upload.slim
+++ b/guide/content/form-elements/file-upload.slim
@@ -14,4 +14,8 @@ p.govuk-body
   caption: 'File upload with label and hint',
   code: file_upload)
 
+== render('/partials/example.*',
+  caption: 'Javascript-enhanced file upload with label and hint',
+  code: file_upload_javascript)
+
 == render('/partials/related-navigation.*', links: file_info)

--- a/guide/lib/examples/file.rb
+++ b/guide/lib/examples/file.rb
@@ -7,5 +7,14 @@ module Examples
           hint: { text: 'Upload a clear colour photograph of yourself looking straight at the camera' }
       SNIPPET
     end
+
+    def file_upload_javascript
+      <<~SNIPPET
+        = f.govuk_file_field :profile_photo,
+          label: { text: 'Identification photograph' },
+          hint: { text: 'Upload a clear colour photograph of yourself looking straight at the camera' },
+          javascript: true
+      SNIPPET
+    end
   end
 end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -1064,8 +1064,8 @@ module GOVUKDesignSystemFormBuilder
     # @note Remember to set +multipart: true+ when creating a form with file
     #   uploads, {https://guides.rubyonrails.org/form_helpers.html#uploading-files see
     #   the Rails documentation} for more information
-    def govuk_file_field(attribute_name, label: {}, caption: {}, hint: {}, form_group: {}, **kwargs, &block)
-      Elements::File.new(self, object_name, attribute_name, label:, caption:, hint:, form_group:, **kwargs, &block).html
+    def govuk_file_field(attribute_name, label: {}, caption: {}, hint: {}, form_group: {}, javascript: false, **kwargs, &block)
+      Elements::File.new(self, object_name, attribute_name, label:, caption:, hint:, form_group:, javascript:, **kwargs, &block).html
     end
   end
 end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -1046,6 +1046,7 @@ module GOVUKDesignSystemFormBuilder
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param form_group [Hash] configures the form group
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @param javascript [Boolean] Configures whether to add HTML for the javascript-enhanced version of the component
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     #
     # @example A photo upload field with file type specifier and injected content

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -10,7 +10,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::HTMLAttributes
       include Traits::HTMLClasses
 
-      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, form_group:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, form_group:, javascript:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
         @label           = label
@@ -18,18 +18,27 @@ module GOVUKDesignSystemFormBuilder
         @hint            = hint
         @html_attributes = kwargs
         @form_group      = form_group
+        @javascript      = javascript
       end
 
       def html
         Containers::FormGroup.new(*bound, **@form_group).html do
-          safe_join([label_element, supplemental_content, hint_element, error_element, file])
+          safe_join([label_element, supplemental_content, hint_element, error_element, file_html])
         end
       end
 
     private
 
+      def file_html
+        @javascript ? file_with_javascript_markup : file
+      end
+
       def file
         @builder.file_field(@attribute_name, attributes(@html_attributes))
+      end
+
+      def file_with_javascript_markup
+        tag.div(class: "#{brand}-drop-zone", data: { module: "#{brand}-file-upload" }) { file }
       end
 
       def options

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -60,5 +60,15 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that accepts a plain ruby object' do
       let(:described_element) { ['input', { with: { type: 'file' } }] }
     end
+
+    context "when the javascript flag is enabled" do
+      subject { builder.send(*args, javascript: true) }
+
+      it "adds the JS enhancement markup" do
+        expect(subject).to have_tag('div', with: { class: 'govuk-drop-zone', "data-module": "govuk-file-upload" }) do
+          expect(subject).to have_tag('input', with: { type: 'file' })
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The latest version of govuk-frontend ([v5.9.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0)) includes a new JS-enhanced version of the file upload component.

The nunjucks macro has a `javascript` flag for enabling this:
```njk
{{ govukFileUpload({
	id: "file-upload",
	name: "photo",
	label: {
		text: "Upload your photo"
	},
	javascript: true
}) }}
```

which inserts a div with a class and data attribute around the input element:

```html
<div class="govuk-form-group">
  <label class="govuk-label" for="file-upload-1">
    Upload a file
  </label>
  <div
    class="govuk-drop-zone"
    data-module="govuk-file-upload">
    <input class="govuk-file-upload" id="file-upload-1" name="fileUpload1" type="file">
  </div>
</div>
```

This PR adds a new javascript flag to the govuk_file_field to accomplish the same thing.
```ruby
<%= form_builder.govuk_file_field :file,
        id: "file-upload",
	name: "photo",
	label: {
	  text: "Upload your photo"
	},
	javascript: true
%>
```